### PR TITLE
Added shebang and setup script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Wappalyzer CLI tool to find Web Technologies
 
 
 ```
-root@kali:~/tools/wappalyzer-cli# python3 wappy.py -h
+root@kali:~/tools/wappalyzer-cli# wappy -h
 
-usage: wappy.py [-h] [-u URL] [-f FILE]
+usage: wappy [-h] [-u URL] [-f FILE]
 
 Finds Web Technologies !
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Wappalyzer CLI tool to find Web Technologies
 
 > cd wappalyzer-cli
 
-> pip3 install -r requirements.txt
+> pip3 install .
 
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+from setuptools import *
+
+
+
+
+
+
+
+if __name__ == "__main__":
+
+
+
+    f = open("requirements.txt", 'r')
+
+    dependencies = f.read().splitlines()
+
+    f.close()
+
+    setup(
+    scripts = ["src/wappy"],
+    name='wappalyzer-cli',
+    version='0.1.0',
+    packages=find_packages(),
+    install_requires=[
+        dependencies
+    ],
+    
+    
+    )

--- a/src/wappy
+++ b/src/wappy
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from Wappalyzer import Wappalyzer, WebPage
 import argparse
 import requests


### PR DESCRIPTION
So wappy can be run without cd'ing into the folder containing the script and running 'python wappy.py arguments' .
Now you can just install wappy as a module with the instruction i added in the readme and run it as 'wappy arguments' without needing to cd into it.