### PR TITLE
changes required for virtual environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Wappalyzer CLI tool to find Web Technologies
 
 > cd wappalyzer-cli
 
+> python3 -m venv venv
+
+> source venv/bin/activate
+
 > pip3 install .
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ colorama
 requests
 argparse
 python-Wappalyzer
+setuptools


### PR DESCRIPTION
Systemwide installs of dependencies via pip arer no longer supported.
This adds `setuptools` to the requirements to enable usage of python's venv module.